### PR TITLE
Netlify redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
 # Netlify redirect as a walkaround for HTTP security concerns
 
-/api/* http://api.marketstack.com/v1/eod:splat 200!
+/api/* http://api.marketstack.com/v1/eod:splat 200

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
 # Netlify redirect as a walkaround for HTTP security concerns
 
-*/api/* http://api.marketstack.com/v1/eod:splat 200!
+*/api/* http://api.marketstack.com/v1/eod/:splat 200!

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+# Netlify redirect as a walkaround for HTTP security concerns
+
+/api/* http://api.marketstack.com/v1/eod:splat 200!

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
 # Netlify redirect as a walkaround for HTTP security concerns
 
-/api/* http://api.marketstack.com/v1/eod:splat 200
+*/api/* http://api.marketstack.com/v1/eod:splat 200!

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
 # Netlify redirect as a walkaround for HTTP security concerns
 
-*/api/* http://api.marketstack.com/v1/eod/:splat 200!
+/api/* http://api.marketstack.com/v1/eod/:splat 200!

--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ const percEl = document.querySelector('.percentage');
 const percValue = document.querySelector('.percentage-value');
 
 // const apiURL = 'http://api.marketstack.com/v1/eod';
-const key = 'c48970cc137ba88422dfb828092901cb';
+const key = '3836e64d9024018914f686e50934041a';
 
 function displayInputErorr(flag) {
   const errorHTML =

--- a/script.js
+++ b/script.js
@@ -54,7 +54,7 @@ async function fetchData(ticker, exchange, date) {
     displayAPIError(1);
     return false;
   }
-  console.log(json.data);
+  console.log(json);
   return Math.round(json.data[0].close);
 }
 

--- a/script.js
+++ b/script.js
@@ -54,6 +54,7 @@ async function fetchData(ticker, exchange, date) {
     displayAPIError(1);
     return false;
   }
+  console.log(json.data);
   return Math.round(json.data[0].close);
 }
 

--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ const PLValue = document.querySelector('.profit-or-loss-value');
 const percEl = document.querySelector('.percentage');
 const percValue = document.querySelector('.percentage-value');
 
-const apiURL = 'http://api.marketstack.com/v1/eod';
+// const apiURL = 'http://api.marketstack.com/v1/eod';
 const key = 'c48970cc137ba88422dfb828092901cb';
 
 function displayInputErorr(flag) {
@@ -39,7 +39,7 @@ function displayAPIError(code) {
 }
 
 async function fetchData(ticker, exchange, date) {
-  const fetchURL = `${apiURL}/${date}?access_key=${key}&symbols=${ticker}.${exchange}`;
+  const fetchURL = `/api/${date}?access_key=${key}&symbols=${ticker}.${exchange}`;
 
   const urlData = await fetch(fetchURL);
 

--- a/script.js
+++ b/script.js
@@ -39,7 +39,7 @@ function displayAPIError(code) {
 }
 
 async function fetchData(ticker, exchange, date) {
-  const fetchURL = `/api/${date}?access_key=${key}&symbols=${ticker}.${exchange}`;
+  const fetchURL = `https://abinjohn-pl-calculator.netlify.app/api/${date}?access_key=${key}&symbols=${ticker}.${exchange}`;
 
   const urlData = await fetch(fetchURL);
 


### PR DESCRIPTION
Include a `_redirect` file for Netlify to redirect API call to a HTTP endpoint.

Some browsers have an issue when an HTTPS site tries to access an HTTP endpoint. This redirect is a walkaround for that.